### PR TITLE
Fix mix.exs lint error (deps())

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Tanegashima.Mixfile do
        licenses: ["MIT"],
        links: %{"GitHub" => "https://github.com/massn/Tanegashima"}
        ],
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
This PR fixes the lint error in mix.exs where `deps` has been called, but Elixir thinks it's a variable.